### PR TITLE
feat(admin-login): 관리자 로그인 및 로그아웃 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.55.0",
+        "react-router-dom": "^7.5.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.23.0",
@@ -1364,6 +1366,12 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -2614,6 +2622,15 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/core-js-pure": {
       "version": "3.41.0",
@@ -5529,6 +5546,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.0.tgz",
+      "integrity": "sha512-estOHrRlDMKdlQa6Mj32gIks4J+AxNsYoE0DbTTxiMy2mPzZuWSDU+N85/r1IlNR7kGfznF3VCUlvc5IUO+B9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.0.tgz",
+      "integrity": "sha512-fFhGFCULy4vIseTtH5PNcY/VvDJK5gvOWcwJVHQp8JQcWVr85ENhJ3UpuF/zP1tQOIFYNRJHzXtyhU1Bdgw0RA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5816,6 +5873,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6399,6 +6462,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6992,6 +7061,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.55.0",
+    "react-router-dom": "^7.5.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,36 @@
-// src/App.tsx
-import EventUploadPage from "@pages/EventUploadPage";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from "react-router-dom";
+import AdminLogin from "./pages/AdminLogin";
+import AdminHome from "./pages/AdminHome";
+import { useAuthStore } from "@/stores/authStore";
 
 function App() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+
   return (
-    <div className="p-4">
-      <EventUploadPage />
-    </div>
+    <Router>
+      <Routes>
+        {/* 첫 랜딩 페이지: 로그인 상태에 따라 리다이렉트 */}
+        <Route
+          path="/"
+          element={
+            isLoggedIn ? (
+              <Navigate to="/admin-home" />
+            ) : (
+              <Navigate to="/admin-login" />
+            )
+          }
+        />
+        {/* 관리자 로그인 페이지 */}
+        <Route path="/admin-login" element={<AdminLogin />} />
+        {/* 행사 업로드 페이지 */}
+        <Route path="/admin-home" element={<AdminHome />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,18 @@ import {
   Route,
   Navigate,
 } from "react-router-dom";
+import { useEffect } from "react";
 import AdminLogin from "./pages/AdminLogin";
 import AdminHome from "./pages/AdminHome";
 import { useAuthStore } from "@/stores/authStore";
 
 function App() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const checkExpiration = useAuthStore((state) => state.checkExpiration);
+
+  useEffect(() => {
+    checkExpiration(); // 애플리케이션 로드 시 만료 확인
+  }, [checkExpiration]);
 
   return (
     <Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import EventUploadPage from "@pages/EventUploadPage"; 
+import EventUploadPage from "@pages/EventUploadPage";
 
 function App() {
   return (

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,10 +1,17 @@
 import { useState } from "react";
 import { Input } from "@components/ui/input";
 import { Button } from "@components/ui/button";
+import { useAuthStore } from "@/stores/authStore";
+import { useNavigate } from "react-router-dom";
 
 export function LoginForm() {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
+
+  // zustand store에서 로그인 함수 가져오기
+  const login = useAuthStore((state) => state.login);
+
+  const navigate = useNavigate();
 
   // 환경 변수에서 아이디와 비밀번호 가져오기
   const ADMIN_ID = import.meta.env.VITE_ADMIN_ID;
@@ -16,7 +23,9 @@ export function LoginForm() {
 
     // 로그인 로직
     if (id === ADMIN_ID && password === ADMIN_PASSWORD) {
+      login(); // zustand의 로그인 함수 호출
       alert("로그인 성공!");
+      navigate("/admin-home"); // 로그인 성공 시 AdminHome으로 이동
     } else {
       alert("아이디 또는 비밀번호가 잘못되었습니다.");
     }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Input } from "@components/ui/input";
+import { Button } from "@components/ui/button";
+
+export function LoginForm() {
+  const [id, setId] = useState("");
+  const [password, setPassword] = useState("");
+
+  // 환경 변수에서 아이디와 비밀번호 가져오기
+  const ADMIN_ID = import.meta.env.VITE_ADMIN_ID;
+  const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    // 폼 제출 시 페이지 새로고침 방지
+    e.preventDefault();
+
+    // 로그인 로직
+    if (id === ADMIN_ID && password === ADMIN_PASSWORD) {
+      alert("로그인 성공!");
+    } else {
+      alert("아이디 또는 비밀번호가 잘못되었습니다.");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto mt-12">
+      <div>
+        <label htmlFor="id" className="block text-sm font-medium">
+          아이디
+        </label>
+        <Input
+          id="id"
+          type="text"
+          placeholder="아이디를 입력하세요"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="password" className="block text-sm font-medium">
+          비밀번호
+        </label>
+        <Input
+          id="password"
+          type="password"
+          placeholder="비밀번호를 입력하세요"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+
+      <Button type="submit" className="w-full">
+        로그인
+      </Button>
+    </form>
+  );
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -24,7 +24,6 @@ export function LoginForm() {
     // 로그인 로직
     if (id === ADMIN_ID && password === ADMIN_PASSWORD) {
       login(); // zustand의 로그인 함수 호출
-      alert("로그인 성공!");
       navigate("/admin-home"); // 로그인 성공 시 AdminHome으로 이동
     } else {
       alert("아이디 또는 비밀번호가 잘못되었습니다.");

--- a/src/components/LogoutBtn.tsx
+++ b/src/components/LogoutBtn.tsx
@@ -1,0 +1,19 @@
+import { Button } from "@components/ui/button";
+import { useAuthStore } from "@/stores/authStore";
+import { useNavigate } from "react-router-dom";
+
+export function LogoutBtn() {
+  const logout = useAuthStore((state) => state.logout);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout(); // zustand의 로그아웃 함수 호출
+    navigate("/admin-login"); // 로그아웃 후 AdminLogin으로 이동
+  };
+
+  return (
+    <Button onClick={handleLogout} className="w-full mt-4">
+      로그아웃
+    </Button>
+  );
+}

--- a/src/pages/AdminHome.tsx
+++ b/src/pages/AdminHome.tsx
@@ -1,5 +1,12 @@
-import { Button } from "@/components/ui/button";
+import { LogoutBtn } from "@/components/LogoutBtn";
 
 export default function AdminHome() {
-  return <Button>로그아웃</Button>;
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold mb-6">관리자 홈</h1>
+        <LogoutBtn />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/AdminHome.tsx
+++ b/src/pages/AdminHome.tsx
@@ -1,0 +1,5 @@
+import { Button } from "@/components/ui/button";
+
+export default function AdminHome() {
+  return <Button>로그아웃</Button>;
+}

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -1,0 +1,12 @@
+import { LoginForm } from "@/components/LoginForm";
+
+export default function AdminLogin() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="w-full max-w-md p-8 bg-white rounded-lg shadow-md">
+        <h2 className="text-2xl font-bold text-center mb-6">관리자 로그인</h2>
+        <LoginForm />
+      </div>
+    </div>
+  );
+}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,6 +5,7 @@ type AuthState = {
   isLoggedIn: boolean;
   login: () => void;
   logout: () => void;
+  checkExpiration: () => void;
 };
 
 export const useAuthStore = create(
@@ -15,12 +16,26 @@ export const useAuthStore = create(
 
       // 로그인 함수
       login: () => {
+        const expirationDate = new Date();
+        expirationDate.setDate(expirationDate.getDate() + 7); // 7일 후 로그인 만료
+        localStorage.setItem("authExpiration", expirationDate.toISOString()); // 만료 시간 저장
         set({ isLoggedIn: true });
       },
 
       // 로그아웃 함수
       logout: () => {
+        localStorage.removeItem("authExpiration");
         set({ isLoggedIn: false });
+      },
+
+      // 만료 확인 함수
+      checkExpiration: () => {
+        const expiration = localStorage.getItem("authExpiration"); // 로그아웃 상태면 expiration이 null
+        // expiration이 null이 아니고(로그인 되어 있고), 만료 시간이 현재 시간보다 이전이면 자동 로그아웃 처리
+        if (expiration && new Date(expiration) < new Date()) {
+          set({ isLoggedIn: false });
+          localStorage.removeItem("authExpiration");
+        }
       },
     }),
     {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type AuthState = {
+  isLoggedIn: boolean;
+  login: () => void;
+  logout: () => void;
+};
+
+export const useAuthStore = create(
+  persist<AuthState>(
+    (set) => ({
+      // 초기 로그아웃 상태
+      isLoggedIn: false,
+
+      // 로그인 함수
+      login: () => {
+        set({ isLoggedIn: true });
+      },
+
+      // 로그아웃 함수
+      logout: () => {
+        set({ isLoggedIn: false });
+      },
+    }),
+    {
+      name: "auth-storage", // localStorage에 저장될 키 이름
+      storage: {
+        getItem: (name) => {
+          const item = localStorage.getItem(name);
+          return item ? JSON.parse(item) : null;
+        },
+        setItem: (name, value) => {
+          localStorage.setItem(name, JSON.stringify(value));
+        },
+        removeItem: (name) => {
+          localStorage.removeItem(name);
+        },
+      },
+    }
+  )
+);


### PR DESCRIPTION
- LoginForm 컴포넌트 생성 및 AdminLogin 페이지에 적용
- .env 파일을 통해 관리자 계정 정보 관리 (보안상 GitHub 제외)
- zustand와 persist 사용하여 로그인 상태 관리 구현
- authStore에 만료 확인 함수를 사용하여 7일 미접속시 자동 로그아웃 처리
- 로그인 후 AdminHome으로 이동하도록 라우팅 처리
- LogoutBtn 컴포넌트 생성 및 로그아웃 기능 구현