### PR TITLE
[fix] 행사 상세 페이지 description, registrationUrl에 break-words 클래스 추가

### DIFF
--- a/src/pages/AdminArticleDetail.tsx
+++ b/src/pages/AdminArticleDetail.tsx
@@ -118,7 +118,7 @@ export default function AdminArticleDetail() {
                   {article.description && (
                     <div className="prose max-w-none mb-6">
                       <h2 className="text-lg font-semibold mb-2">행사 설명</h2>
-                      <p className="whitespace-pre-line">
+                      <p className="whitespace-pre-line break-words">
                         {article.description}
                       </p>
                     </div>
@@ -131,7 +131,7 @@ export default function AdminArticleDetail() {
                         href={article.registrationUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-blue-600 hover:underline"
+                        className="break-words text-blue-600 hover:underline"
                       >
                         {article.registrationUrl}
                       </a>

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -357,7 +357,7 @@ export default function ArticleDetailPage() {
           </div>
         )}
         <div ref={descRef} className="pt-8 pr-5 pb-10 pl-5 gap-2.5">
-          <div className="whitespace-pre-line font-normal text-body1 text-gray-800 font-pretendard">
+          <div className="whitespace-pre-line break-words font-normal text-body1 text-gray-800 font-pretendard">
             {article.description}
           </div>
         </div>


### PR DESCRIPTION
- 긴 URL이 중앙 컨텐츠 프레임 밖으로 넘어가는 문제 해결